### PR TITLE
Adding Cache-Control Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cookie-session": "^1.1.0",
     "debug": "^2.2.0",
     "express": "^4.12.4",
+    "express-cache-response-directive": "^0.2.0",
     "express-jefferson": "^2.1.0",
     "express-mountie": "^3.0.0",
     "express-session": "^1.11.3",

--- a/server/initialization/index.js
+++ b/server/initialization/index.js
@@ -3,6 +3,7 @@ let debug = require("debug")("app:initialization");
 const INIT_SECTIONS = [
     require("./sections/helmet"),
     require("./sections/force_ssl"),
+    require("./sections/cache_control"),
     require("./sections/compression"),
     require("./sections/body_parsing"),
     require("./sections/static_content"),

--- a/server/initialization/sections/cache_control.js
+++ b/server/initialization/sections/cache_control.js
@@ -1,0 +1,9 @@
+"use strict";
+let cacheResponseDirective = require("express-cache-response-directive");
+
+module.exports = {
+    name: "cache control",
+    configure(app) {
+        app.use(cacheResponseDirective());
+    }
+};

--- a/server/middleware/cache.js
+++ b/server/middleware/cache.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/**
+ * A middleware function ta add client-side cache-control headers
+ * @param directive
+ */
+module.exports = (directive) => (req, res, next) => {
+    res.cacheControl(directive);
+    next();
+};

--- a/server/routers/drugs/index.js
+++ b/server/routers/drugs/index.js
@@ -3,8 +3,12 @@ let jefferson = require("express-jefferson");
 let mountie = require("express-mountie");
 let path = require("path");
 let drugs = require("../../middleware/drugs");
+let cache = require("../../middleware/cache");
 
 let router = jefferson.router({
+    pre: {
+        all: [cache({maxAge: 3600})]
+    },
     routes: {
         "/": {
             "get": [drugs.index]

--- a/server/routers/drugs/routers/by-spl-set-id.js
+++ b/server/routers/drugs/routers/by-spl-set-id.js
@@ -2,8 +2,12 @@
 let jefferson = require("express-jefferson");
 let debug = require("../../../middleware/debug");
 let drugs = require("../../../middleware/drugs");
+let cache = require("../../../middleware/cache");
 
 module.exports = jefferson.router({
+    pre: {
+        all: [cache({maxAge: 3600})]
+    },
     routes: {
         "/": {
             get: [debug.send("NotImplemented - send an index (no data)")]

--- a/server/routers/drugs/routers/events.js
+++ b/server/routers/drugs/routers/events.js
@@ -1,8 +1,11 @@
 "use strict";
 let jefferson = require("express-jefferson");
 let drugs = require("../../../middleware/drugs");
-
+let cache = require("../../../middleware/cache");
 module.exports = jefferson.router({
+    pre: {
+        all: [cache({maxAge: 3600})]
+    },
    routes: {
        "/": {
            get: [drugs.events]

--- a/server/routers/manufacturers/index.js
+++ b/server/routers/manufacturers/index.js
@@ -3,8 +3,12 @@ let jefferson = require("express-jefferson");
 let manufacturers = require("../../middleware/manufacturers");
 let mountie = require("express-mountie");
 let path = require("path");
+let cache = require("../../middleware/cache");
 
 let router = jefferson.router({
+    pre: {
+        all: [cache({maxAge: 3600})]
+    },
     routes: {
         "/": {
             "get": [manufacturers.index]

--- a/server/routers/manufacturers/routers/by-name.js
+++ b/server/routers/manufacturers/routers/by-name.js
@@ -1,9 +1,13 @@
 "use strict";
 let jefferson = require("express-jefferson");
 let manufacturers = require("../../../middleware/manufacturers");
+let cache = require("../../../middleware/cache");
 
 module.exports = jefferson.router({
     proxies: [require("express-jefferson/proxies/promise-handler")],
+    pre: {
+        all: [cache({maxAge: 3600})]
+    },
     routes: {
         "/": {
             get: [manufacturers.getManufacturerByName]


### PR DESCRIPTION
Invocations of the OpenFDA API are now protected via cache-control headers. Individual client browsers will cache the responses for 1 hour, improving their own experience and our throttling thresholds.
